### PR TITLE
Terraform deploys latest tag

### DIFF
--- a/.github/workflows/terraform_deploy.yml
+++ b/.github/workflows/terraform_deploy.yml
@@ -43,7 +43,7 @@ jobs:
       run: |
         export LATEST_TAG_GIT
         LATEST_TAG_GIT=$(git describe --tags "$(git rev-list --tags --max-count=1)")
-        echo "LATEST_TAG=$LATEST_TAG_GIT" >> $GITHUB_ENV
+        echo "LATEST_TAG=$LATEST_TAG_GIT" >> "$GITHUB_ENV"
 
     - name: Add latest tag to tfvars
       if: ${{ inputs.deployLatestTag }} == true


### PR DESCRIPTION
The Terraform deploy workflow now deploys the latest tagged version rather than simply deploying "latest"

Part of: 
https://github.com/TheBatchelorFamily/Megans_Portfolio_Website/issues/15